### PR TITLE
fix: daily searches never ran after the WXT migration

### DIFF
--- a/wxt/entrypoints/background.ts
+++ b/wxt/entrypoints/background.ts
@@ -2,6 +2,7 @@ import { defineBackground } from '#imports';
 import { browser } from 'wxt/browser';
 import { handleInstallOrUpdate, handleStartup, runRewards } from './background/dailySchedule';
 import { handleAlarmStep, stopSearches, watchSearchesToggle } from './background/searchRunner';
+import { isCleanupAlarm, sweepStaleTabs } from './background/tabCleanup';
 
 export default defineBackground(() => {
     browser.runtime.onInstalled.addListener(handleInstallOrUpdate);
@@ -11,5 +12,10 @@ export default defineBackground(() => {
         if (request.action === 'popup') void runRewards();
         else if (request.action === 'stop') void stopSearches();
     });
-    browser.alarms.onAlarm.addListener((alarm) => void handleAlarmStep(alarm));
+    // Registered here, at the worker's top level, so the browser wakes a
+    // torn-down service worker for it — the only kind of timer that survives.
+    browser.alarms.onAlarm.addListener((alarm) => {
+        if (isCleanupAlarm(alarm.name)) void sweepStaleTabs();
+        else void handleAlarmStep(alarm);
+    });
 });

--- a/wxt/entrypoints/background/dailyRewards.ts
+++ b/wxt/entrypoints/background/dailyRewards.ts
@@ -1,5 +1,6 @@
 import { browser } from 'wxt/browser';
 import { getRndInteger } from '@/entrypoints/utils/helpers';
+import { trackTab, untrackTab } from './tabCleanup';
 
 // Safety cap: close the dashboard tab even if the content script never reports
 // done (page failed to render the daily sets, message dropped, etc.).
@@ -28,6 +29,9 @@ export async function openDailyRewards(): Promise<void> {
 
     const tab = await browser.tabs.create({ url: 'https://rewards.bing.com/dashboard', active: true });
     const dashboardId = tab.id!;
+    // The `finish` timer below is the precise close; this is the backstop for
+    // when the service worker is torn down before it ever fires.
+    await trackTab(dashboardId, DAILY_TAB_MAX_LIFETIME_MS);
 
     function onCreated(created: { id?: number; openerTabId?: number }): void {
         if (created.openerTabId !== dashboardId || created.id == null) return;
@@ -45,6 +49,7 @@ export async function openDailyRewards(): Promise<void> {
         browser.runtime.onMessage.removeListener(doneListener);
         browser.tabs.onCreated.removeListener(onCreated);
         browser.tabs.remove(dashboardId).catch(() => {});
+        void untrackTab(dashboardId);
         if (previousActiveTabId != null) {
             browser.tabs.update(previousActiveTabId, { active: true }).catch(() => {});
         }
@@ -90,12 +95,14 @@ async function getActiveTabId(): Promise<number | undefined> {
 // Close a daily-set search tab a random few seconds after it finishes loading,
 // with a hard cap in case it never reports "complete".
 function closeDailyTabAfterLoad(tabId: number): void {
+    void trackTab(tabId, DAILY_LINK_HARD_CLOSE_MS);
     let closed = false;
     function close(): void {
         if (closed) return;
         closed = true;
         browser.tabs.onUpdated.removeListener(loadListener);
         browser.tabs.get(tabId).then(() => browser.tabs.remove(tabId)).catch(() => {});
+        void untrackTab(tabId);
     }
     function loadListener(updatedId: number, changeInfo: { status?: string }): void {
         if (updatedId === tabId && changeInfo.status === 'complete') {

--- a/wxt/entrypoints/background/dailyRewards.ts
+++ b/wxt/entrypoints/background/dailyRewards.ts
@@ -11,6 +11,10 @@ const DAILY_LINK_MAX_LINGER_MS = 5000;
 // Fallback: close a daily-set tab this long after it opened even if it never
 // reports "complete".
 const DAILY_LINK_HARD_CLOSE_MS = 20000;
+// Give up waiting on the dashboard to load rather than leaving the promise
+// pending forever when the tab is closed (by the user or by `finish`) or the
+// load event never arrives.
+const DASHBOARD_LOAD_TIMEOUT_MS = 30000;
 
 // Opens the rewards dashboard and tells the content script to click the
 // daily-set cards (that click is what credits the points). The dashboard is
@@ -53,16 +57,24 @@ export async function openDailyRewards(): Promise<void> {
     setTimeout(finish, DAILY_TAB_MAX_LIFETIME_MS);
 
     await new Promise<void>((resolve) => {
+        let isSettled = false;
+        function settle(): void {
+            if (isSettled) return;
+            isSettled = true;
+            browser.tabs.onUpdated.removeListener(loadListener);
+            clearTimeout(giveUpTimer);
+            resolve();
+        }
         function loadListener(updatedId: number, changeInfo: { status?: string }): void {
-            if (updatedId === dashboardId && changeInfo.status === 'complete') {
-                browser.tabs.onUpdated.removeListener(loadListener);
-                setTimeout(() => {
-                    browser.tabs.sendMessage(dashboardId, { action: 'openDaily' }).catch(() => {});
-                    resolve();
-                }, 300);
-            }
+            if (updatedId !== dashboardId || changeInfo.status !== 'complete') return;
+            browser.tabs.onUpdated.removeListener(loadListener);
+            setTimeout(() => {
+                browser.tabs.sendMessage(dashboardId, { action: 'openDaily' }).catch(() => {});
+                settle();
+            }, 300);
         }
         browser.tabs.onUpdated.addListener(loadListener);
+        const giveUpTimer = setTimeout(settle, DASHBOARD_LOAD_TIMEOUT_MS);
     });
 }
 

--- a/wxt/entrypoints/background/dailySchedule.test.ts
+++ b/wxt/entrypoints/background/dailySchedule.test.ts
@@ -3,7 +3,7 @@
 // WXT's `#imports` transform triggers (same reason as searchRunner.test.ts).
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing';
-import { handleInstallOrUpdate, runRewards } from './dailySchedule';
+import { handleInstallOrUpdate, handleStartup, runRewards } from './dailySchedule';
 import { getStorageItem, setStorageItems } from '@/entrypoints/hooks/useStorage';
 import { StorageValues } from '@/entrypoints/enums/storageValues';
 
@@ -88,6 +88,48 @@ describe('runRewards', () => {
     await flushPendingWork();
 
     expect(urls).toEqual([]);
+  });
+});
+
+describe('handleStartup', () => {
+  beforeEach(() => {
+    fakeBrowser.reset();
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  // The automatic daily run is the path users actually hit, so the "Daily set"
+  // toggle has to be honoured there too, not just on the popup's button.
+  it('opens no dashboard on the automatic daily run when "Daily set" is off', async () => {
+    const urls = trackCreatedTabs();
+    await seed({ active: true, autoDaily: false });
+
+    await handleStartup();
+    await flushPendingWork();
+
+    expect(urls).not.toContain(DASHBOARD_URL);
+    expect(urls.some((url) => url.startsWith('https://www.bing.com/search?q='))).toBe(true);
+  });
+
+  it('opens the dashboard on the automatic daily run when "Daily set" is on', async () => {
+    const urls = trackCreatedTabs();
+    await seed({ active: false, autoDaily: true });
+
+    await handleStartup();
+    await flushPendingWork();
+
+    expect(urls).toEqual([DASHBOARD_URL]);
+  });
+
+  it('drops a tab registry left over from the previous session', async () => {
+    // Both toggles off, so no run starts and re-registers tabs of its own.
+    await seed({ active: false, autoDaily: false });
+    await setStorageItems({ trackedTabs: { 7: 1 } }, StorageValues.LOCAL);
+
+    await handleStartup();
+
+    expect(await getStorageItem('trackedTabs', StorageValues.LOCAL)).toEqual({});
   });
 });
 

--- a/wxt/entrypoints/background/dailySchedule.test.ts
+++ b/wxt/entrypoints/background/dailySchedule.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment node
+// Background scheduling needs no DOM; node avoids the esbuild/jsdom clash that
+// WXT's `#imports` transform triggers (same reason as searchRunner.test.ts).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+import { handleInstallOrUpdate, runRewards } from './dailySchedule';
+import { getStorageItem, setStorageItems } from '@/entrypoints/hooks/useStorage';
+import { StorageValues } from '@/entrypoints/enums/storageValues';
+
+const DASHBOARD_URL = 'https://rewards.bing.com/dashboard';
+
+function trackCreatedTabs(): string[] {
+  const urls: string[] = [];
+  vi.spyOn(fakeBrowser.tabs, 'create').mockImplementation(async (info: any) => {
+    urls.push(String(info.url));
+    return { id: urls.length } as any;
+  });
+  return urls;
+}
+
+// The daily-set run is deliberately fire-and-forget, so it is still mid-flight
+// when runRewards resolves; let its pending work settle before asserting on tabs.
+async function flushPendingWork(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+async function seed(values: Record<string, unknown>): Promise<void> {
+  await setStorageItems(
+    { active: true, autoDaily: true, searches: 5, timeout: 60, closeTime: 5, ...values },
+    StorageValues.SYNC
+  );
+}
+
+describe('runRewards', () => {
+  beforeEach(() => {
+    fakeBrowser.reset();
+    vi.restoreAllMocks();
+    // The daily-set flow arms long safety timers that nothing in these tests
+    // waits on; fake timers keep them from holding the run open.
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  // Regression: runRewards used to `await openDailyRewards()`, whose load promise
+  // only resolved on the dashboard tab reporting "complete". A dashboard closed by
+  // the user, removed by our own safety timer, or lost to a torn-down MV3 service
+  // worker left that promise pending forever, so startSearches was never reached
+  // and not a single search ran all day.
+  it('starts the searches even when the dashboard never reports "complete"', async () => {
+    const urls = trackCreatedTabs();
+    await seed({});
+
+    await runRewards();
+    await flushPendingWork();
+
+    expect(urls).toContain(DASHBOARD_URL);
+    expect(urls.some((url) => url.startsWith('https://www.bing.com/search?q='))).toBe(true);
+    expect(await getStorageItem<boolean>('isSearching', StorageValues.SYNC)).toBe(true);
+  });
+
+  it('opens no dashboard when "Daily set" is off, but still searches', async () => {
+    const urls = trackCreatedTabs();
+    await seed({ autoDaily: false });
+
+    await runRewards();
+    await flushPendingWork();
+
+    expect(urls).not.toContain(DASHBOARD_URL);
+    expect(urls.some((url) => url.startsWith('https://www.bing.com/search?q='))).toBe(true);
+  });
+
+  it('runs no searches when "Daily searches" is off, but still opens the dashboard', async () => {
+    const urls = trackCreatedTabs();
+    await seed({ active: false });
+
+    await runRewards();
+    await flushPendingWork();
+
+    expect(urls).toEqual([DASHBOARD_URL]);
+    expect(await getStorageItem<boolean>('isSearching', StorageValues.SYNC)).not.toBe(true);
+  });
+
+  it('opens nothing when both toggles are off', async () => {
+    const urls = trackCreatedTabs();
+    await seed({ active: false, autoDaily: false });
+
+    await runRewards();
+    await flushPendingWork();
+
+    expect(urls).toEqual([]);
+  });
+});
+
+describe('handleInstallOrUpdate', () => {
+  beforeEach(() => {
+    fakeBrowser.reset();
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  // "Open first result" navigates the search tab off the Bing results page, which
+  // risks the search not being credited, so a fresh install must start with it off.
+  it('seeds a new install with "open first result" disabled', async () => {
+    trackCreatedTabs();
+    // Not implemented by the fake browser, and irrelevant to what this asserts.
+    vi.spyOn(fakeBrowser.runtime, 'setUninstallURL').mockResolvedValue(undefined);
+
+    await handleInstallOrUpdate({ reason: 'install' });
+
+    expect(await getStorageItem<boolean>('openFirstResult', StorageValues.SYNC)).toBe(false);
+  });
+});

--- a/wxt/entrypoints/background/dailySchedule.ts
+++ b/wxt/entrypoints/background/dailySchedule.ts
@@ -9,18 +9,28 @@ import { startSearches } from './searchRunner';
 
 const WEBSITE_URL = 'https://svitspindler.com/microsoft-automatic-rewards';
 
-// Runs whatever the user has enabled: the daily set if "Open daily set
-// automatically" is on, and the Bing searches if "Do daily searches
-// automatically" is on. Both the automatic daily trigger and the popup's
-// "Get rewards" button call this, so the button respects the same toggles
-// rather than forcing searches.
+// Runs whatever the user has enabled: the daily set if "Daily set" is on, and
+// the Bing searches if "Daily searches" is on. Both the automatic daily trigger
+// and the popup's "Get rewards" button call this, so the button respects the
+// same toggles rather than forcing either run.
 export async function runRewards(): Promise<void> {
-    const s = await getStorageItems(['searches', 'timeout', 'closeTime'], StorageValues.SYNC);
+    const s = await getStorageItems(
+        ['searches', 'timeout', 'closeTime', 'active', 'autoDaily'],
+        StorageValues.SYNC
+    );
     const searchTimeout = toInt(s.timeout, DEFAULTS.timeout);
     const searches = toInt(s.searches, DEFAULTS.searches);
     const closeTime = toInt(s.closeTime, DEFAULTS.closeTime);
-    await openDailyRewards();
-    if (searches > 0) {
+    const isDailySetEnabled = s.autoDaily ?? DEFAULTS.autoDaily;
+    const isSearchesEnabled = s.active ?? DEFAULTS.active;
+
+    // The daily set is deliberately NOT awaited: the two runs are independent.
+    // Awaiting it used to serialise the searches behind the dashboard tab
+    // reporting "complete", so a dashboard closed by the user, removed by our
+    // own safety timer, or lost to a torn-down service worker meant not a single
+    // search ran that day.
+    if (isDailySetEnabled) void openDailyRewards().catch(() => {});
+    if (isSearchesEnabled && searches > 0) {
         await startSearches(searchTimeout, searches, closeTime);
     }
 }

--- a/wxt/entrypoints/background/dailySchedule.ts
+++ b/wxt/entrypoints/background/dailySchedule.ts
@@ -3,9 +3,10 @@ import { getStorageItems, setStorageItem, setStorageItems } from '@/entrypoints/
 import { StorageValues } from '@/entrypoints/enums/storageValues';
 import { toInt } from '@/entrypoints/utils/search';
 import { DEFAULTS } from '@/entrypoints/utils/settings';
-import { clearBadge, setBadgeText } from '@/entrypoints/utils/browserAction';
+import { setBadgeText } from '@/entrypoints/utils/browserAction';
 import { openDailyRewards } from './dailyRewards';
-import { startSearches } from './searchRunner';
+import { startSearches, stopSearches } from './searchRunner';
+import { clearTrackedTabs } from './tabCleanup';
 
 const WEBSITE_URL = 'https://svitspindler.com/microsoft-automatic-rewards';
 
@@ -71,9 +72,11 @@ export async function handleStartup(): Promise<void> {
     // today's run is considered: alarms outlive the session and would resume
     // opening Bing tabs on their own, and resetting the flag afterwards used to
     // clobber the `isSearching` that a fresh run had just set.
-    await browser.alarms.clearAll();
-    await setStorageItems({ isSearching: false, currentSearch: 0 }, StorageValues.SYNC);
-    clearBadge();
+    await stopSearches();
+    await setStorageItems({ currentSearch: 0 }, StorageValues.SYNC);
+    // Tab ids do not survive a browser restart, so anything still registered for
+    // cleanup points at tabs that no longer exist.
+    await clearTrackedTabs();
     const s = await getStorageItems(['active', 'autoDaily'], StorageValues.SYNC);
     if (s.active || s.autoDaily) await checkLastOpened();
 }

--- a/wxt/entrypoints/background/searchRunner.test.ts
+++ b/wxt/entrypoints/background/searchRunner.test.ts
@@ -100,7 +100,32 @@ describe('searchRunner', () => {
       await stopSearches();
 
       expect(await getStorageItem<boolean>('isSearching', StorageValues.SYNC)).toBe(false);
-      expect(await fakeBrowser.alarms.getAll()).toEqual([]);
+      expect(await fakeBrowser.alarms.get('openTabAlarm')).toBeUndefined();
+    });
+
+    // Regression: this used to clearAll(), which also wiped the tab-cleanup
+    // sweep and left every tab the run had opened on screen for good.
+    it('leaves the tab-cleanup alarm running', async () => {
+      await seed({ isSearching: true });
+      fakeBrowser.alarms.create('closeStaleTabs', { periodInMinutes: 1 });
+
+      await stopSearches();
+
+      expect(await fakeBrowser.alarms.get('closeStaleTabs')).toBeDefined();
+    });
+  });
+
+  describe('search tab cleanup', () => {
+    // A search tab's own close timer does not survive the service worker being
+    // torn down, so every one is registered for the durable sweep as well.
+    it('registers each search tab for the durable sweep', async () => {
+      await seed({});
+
+      await startSearches(60, 5, 5);
+
+      const tracked = await getStorageItem<Record<string, number>>('trackedTabs', StorageValues.LOCAL);
+      expect(Object.keys(tracked ?? {})).toHaveLength(1);
+      expect(await fakeBrowser.alarms.get('closeStaleTabs')).toBeDefined();
     });
   });
 });

--- a/wxt/entrypoints/background/searchRunner.ts
+++ b/wxt/entrypoints/background/searchRunner.ts
@@ -6,8 +6,13 @@ import { getStorageItem, getStorageItems, setStorageItem, setStorageItems } from
 import { StorageValues } from '@/entrypoints/enums/storageValues';
 import { DEFAULTS } from '@/entrypoints/utils/settings';
 import { clearBadge, setSearchCountBadge } from '@/entrypoints/utils/browserAction';
+import { trackTab, untrackTab } from './tabCleanup';
 
 const ALARM_NAME = 'openTabAlarm';
+// A search tab closes `closeTime` after it finishes loading, so the durable
+// cleanup deadline has to allow for the load on top of that — a slow page must
+// not be swept away before its search has had a chance to register.
+const SEARCH_TAB_LOAD_ALLOWANCE_MS = 60000;
 
 // Opens tab #1 immediately (currentSearch = 1), then schedules the rest via alarm.
 export async function startSearches(searchTimeout: number, searches: number, closeTimeSeconds: number): Promise<void> {
@@ -49,7 +54,9 @@ export async function handleAlarmStep(alarm: { name: string }): Promise<void> {
 export async function stopSearches(): Promise<void> {
     await setStorageItem('isSearching', false, StorageValues.SYNC);
     clearBadge();
-    await browser.alarms.clearAll();
+    // Only this run's alarm: clearAll() also wiped the tab-cleanup sweep, which
+    // left every tab the run had opened on screen for good.
+    await browser.alarms.clear(ALARM_NAME);
 }
 
 // Turning "Daily searches" off has to stop a run that is already in flight —
@@ -87,6 +94,9 @@ async function openSearchTab(closeTimeMs: number): Promise<void> {
 async function openAndClose(url: string, closeTimeMs: number): Promise<void> {
     const tab = await browser.tabs.create({ url, active: false });
     const tabId = tab.id!;
+    // Backstop for the close below, whose timer and listener are both lost when
+    // the service worker is torn down.
+    await trackTab(tabId, closeTimeMs + SEARCH_TAB_LOAD_ALLOWANCE_MS);
     function listener(updatedId: number, changeInfo: { status?: string }): void {
         if (updatedId === tabId && changeInfo.status === 'complete') {
             browser.tabs.onUpdated.removeListener(listener);
@@ -98,7 +108,10 @@ async function openAndClose(url: string, closeTimeMs: number): Promise<void> {
 
 function waitAndClose(id: number, closeTimeMs: number): void {
     const timeout = closeTimeMs <= 0 ? 500 : closeTimeMs;
-    setTimeout(() => {
-        browser.tabs.get(id).then(() => browser.tabs.remove(id)).catch(() => {});
-    }, Math.max(timeout - 500, 0) + getRndInteger(0, 1000));
+    setTimeout(() => void closeTab(id), Math.max(timeout - 500, 0) + getRndInteger(0, 1000));
+}
+
+async function closeTab(id: number): Promise<void> {
+    await browser.tabs.get(id).then(() => browser.tabs.remove(id)).catch(() => {});
+    await untrackTab(id);
 }

--- a/wxt/entrypoints/background/tabCleanup.test.ts
+++ b/wxt/entrypoints/background/tabCleanup.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+import { clearTrackedTabs, isCleanupAlarm, sweepStaleTabs, trackTab, untrackTab } from './tabCleanup';
+
+const CLEANUP_ALARM = 'closeStaleTabs';
+
+async function openTab(id: number): Promise<void> {
+  await fakeBrowser.tabs.create({ url: `https://example.com/${id}` });
+}
+
+async function openTabIds(): Promise<number[]> {
+  return (await fakeBrowser.tabs.query({})).map((tab) => tab.id!);
+}
+
+describe('tabCleanup', () => {
+  beforeEach(() => {
+    fakeBrowser.reset();
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-21T10:00:00Z'));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('arms the sweep alarm as soon as a tab is tracked', async () => {
+    await trackTab(1, 5000);
+
+    expect(await fakeBrowser.alarms.get(CLEANUP_ALARM)).toBeDefined();
+  });
+
+  // The precise close runs on a setTimeout, which an MV3 service worker does not
+  // keep alive. This sweep is what actually closes the tab when that timer is
+  // lost, so a run no longer leaves Bing tabs piled up behind it.
+  it('closes a tracked tab once its deadline has passed', async () => {
+    await openTab(1);
+    const [tabId] = await openTabIds();
+    await trackTab(tabId, 5000);
+
+    vi.setSystemTime(new Date('2026-08-21T10:00:06Z'));
+    await sweepStaleTabs();
+
+    expect(await openTabIds()).not.toContain(tabId);
+  });
+
+  it('leaves a tracked tab alone while its deadline is in the future', async () => {
+    await openTab(1);
+    const [tabId] = await openTabIds();
+    await trackTab(tabId, 60000);
+
+    vi.setSystemTime(new Date('2026-08-21T10:00:06Z'));
+    await sweepStaleTabs();
+
+    expect(await openTabIds()).toContain(tabId);
+    expect(await fakeBrowser.alarms.get(CLEANUP_ALARM)).toBeDefined();
+  });
+
+  it('stops sweeping once nothing is tracked any more', async () => {
+    await openTab(1);
+    const [tabId] = await openTabIds();
+    await trackTab(tabId, 5000);
+
+    vi.setSystemTime(new Date('2026-08-21T10:00:06Z'));
+    await sweepStaleTabs();
+
+    expect(await fakeBrowser.alarms.get(CLEANUP_ALARM)).toBeUndefined();
+  });
+
+  it('does not close a tab that was untracked after closing itself on time', async () => {
+    await openTab(1);
+    const [tabId] = await openTabIds();
+    await trackTab(tabId, 5000);
+    await untrackTab(tabId);
+
+    vi.setSystemTime(new Date('2026-08-21T10:00:06Z'));
+    await sweepStaleTabs();
+
+    expect(await openTabIds()).toContain(tabId);
+    expect(await fakeBrowser.alarms.get(CLEANUP_ALARM)).toBeUndefined();
+  });
+
+  it('survives a tab that is already gone', async () => {
+    await trackTab(4242, 5000);
+
+    vi.setSystemTime(new Date('2026-08-21T10:00:06Z'));
+
+    await expect(sweepStaleTabs()).resolves.toBeUndefined();
+  });
+
+  // Tab ids do not survive a browser restart, so anything carried over from the
+  // previous session points at tabs that no longer exist.
+  it('drops the whole registry on request', async () => {
+    await openTab(1);
+    const [tabId] = await openTabIds();
+    await trackTab(tabId, 5000);
+
+    await clearTrackedTabs();
+    vi.setSystemTime(new Date('2026-08-21T10:00:06Z'));
+    await sweepStaleTabs();
+
+    expect(await openTabIds()).toContain(tabId);
+    expect(await fakeBrowser.alarms.get(CLEANUP_ALARM)).toBeUndefined();
+  });
+
+  it('recognises only its own alarm', () => {
+    expect(isCleanupAlarm(CLEANUP_ALARM)).toBe(true);
+    expect(isCleanupAlarm('openTabAlarm')).toBe(false);
+  });
+});

--- a/wxt/entrypoints/background/tabCleanup.ts
+++ b/wxt/entrypoints/background/tabCleanup.ts
@@ -1,0 +1,79 @@
+import { browser } from 'wxt/browser';
+import { getStorageItem, setStorageItem } from '@/entrypoints/hooks/useStorage';
+import { StorageValues } from '@/entrypoints/enums/storageValues';
+
+// Tab ids the extension opened, each mapped to the wall-clock time by which it
+// must be gone.
+type TrackedTabs = Record<string, number>;
+
+const REGISTRY_KEY = 'trackedTabs';
+const CLEANUP_ALARM = 'closeStaleTabs';
+// Chrome's floor for a repeating alarm. A tab whose in-memory timer was lost
+// therefore closes within about a minute of its deadline instead of never.
+const SWEEP_PERIOD_MINUTES = 1;
+
+export function isCleanupAlarm(name: string): boolean {
+    return name === CLEANUP_ALARM;
+}
+
+// Records a tab the extension opened so that it still gets closed when the
+// setTimeout meant to close it never runs. That is the normal case in an MV3
+// service worker: it is torn down after ~30s idle, taking pending timers and
+// runtime-registered tab listeners with it, which is why search and daily-set
+// tabs used to pile up. Alarms survive that teardown, so the sweep does not.
+export async function trackTab(tabId: number, closeAfterMs: number): Promise<void> {
+    const tracked = await readRegistry();
+    await writeRegistry({ ...tracked, [tabId]: Date.now() + closeAfterMs });
+    browser.alarms.create(CLEANUP_ALARM, { periodInMinutes: SWEEP_PERIOD_MINUTES });
+}
+
+// Called once a tab has closed on time, so the sweep has nothing left to do.
+export async function untrackTab(tabId: number): Promise<void> {
+    const tracked = await readRegistry();
+    if (!(String(tabId) in tracked)) return;
+    await saveRemaining(without(tracked, tabId));
+}
+
+export async function sweepStaleTabs(): Promise<void> {
+    const entries = Object.entries(await readRegistry());
+    const now = Date.now();
+    const due = entries.filter(([, deadline]) => deadline <= now);
+    const remaining = Object.fromEntries(entries.filter(([, deadline]) => deadline > now));
+
+    await Promise.all(due.map(([tabId]) => closeTab(Number(tabId))));
+    await saveRemaining(remaining);
+}
+
+// Tab ids do not survive a browser restart, so a registry carried over from the
+// previous session points at tabs that no longer exist.
+export async function clearTrackedTabs(): Promise<void> {
+    await saveRemaining({});
+}
+
+async function readRegistry(): Promise<TrackedTabs> {
+    return (await getStorageItem<TrackedTabs>(REGISTRY_KEY, StorageValues.LOCAL)) ?? {};
+}
+
+async function writeRegistry(tracked: TrackedTabs): Promise<void> {
+    await setStorageItem(REGISTRY_KEY, tracked, StorageValues.LOCAL);
+}
+
+// Nothing tracked means nothing to sweep, so the alarm is dropped rather than
+// waking the worker every minute for the rest of the session.
+async function saveRemaining(tracked: TrackedTabs): Promise<void> {
+    await writeRegistry(tracked);
+    if (Object.keys(tracked).length === 0) await browser.alarms.clear(CLEANUP_ALARM);
+}
+
+function without(tracked: TrackedTabs, tabId: number): TrackedTabs {
+    return Object.fromEntries(Object.entries(tracked).filter(([id]) => id !== String(tabId)));
+}
+
+async function closeTab(tabId: number): Promise<void> {
+    try {
+        await browser.tabs.get(tabId);
+        await browser.tabs.remove(tabId);
+    } catch {
+        // Already gone — closed by its own timer, or by the user.
+    }
+}

--- a/wxt/entrypoints/bingResult.content.ts
+++ b/wxt/entrypoints/bingResult.content.ts
@@ -2,10 +2,12 @@ import { defineContentScript } from '#imports';
 import { getRndInteger, wait } from '@/entrypoints/utils/helpers';
 import { oncePerPageRun } from '@/entrypoints/utils/oncePerPageRun';
 
-// LOCAL ANALYSIS ONLY — not for shipping. On search tabs the extension opens
-// (tagged with ?marAuto=1), read the first organic Bing result and navigate to
-// it, so its landing page can be reviewed manually before the tab auto-closes.
-// Manual Bing searches lack the marker and are left alone.
+// On search tabs the extension opened (tagged with ?marAuto=1), navigate to the
+// first organic Bing result after a short random delay, so the visit reads as a
+// normal search-and-click rather than a results page nobody looked at. Opt-in
+// from the popup and off by default, since leaving the results page risks the
+// search not being credited. Manual Bing searches lack the marker and are left
+// alone.
 const RESULT_SELECTOR = '#b_results li.b_algo h2 a';
 const MAX_WAIT_MS = 8000;
 // Wait a randomized 1.5–5.5s before opening so it isn't an instant, robotic jump.
@@ -19,11 +21,9 @@ export default defineContentScript({
         if (!oncePerPageRun('_marFirstResultClicked')) return;
 
         const first = await waitForFirstResult();
-        if (!first) {
-            console.warn('[MAR] no organic result found for this query');
-            return;
-        }
-        console.log('[MAR] first result:', first.textContent?.trim(), '→', first.href);
+        // No organic result rendered (ads-only page, layout change, slow load):
+        // leave the tab on the results page rather than guessing at a target.
+        if (!first) return;
         // Randomized pause, then navigate in place. Using location.assign (not
         // anchor.click) keeps navigation in this same background tab: it never
         // spawns a new tab and never activates this one, so the user's current

--- a/wxt/entrypoints/data/searchTerms.ts
+++ b/wxt/entrypoints/data/searchTerms.ts
@@ -1,38 +1,63 @@
 // Building blocks for natural-looking Bing queries. Queries are formed as
-// "<lead-in> <topic>" or "<topic> <tail>" so they read like real searches a
-// person would make (e.g. "best headphones", "gardening for beginners") rather
-// than random word salad or gibberish strings.
+// "<lead-in> <topic>", "<topic> <tail>", or "<lead-in> <topic> <tail>" so they
+// read like real searches a person would make (e.g. "best headphones",
+// "gardening for beginners", "cheap laptops on sale") rather than random word
+// salad or gibberish strings.
+//
+// Pool size matters: a query Microsoft has already seen today earns no points,
+// so these lists are sized so that even a 90-search day rarely repeats itself.
+// Keep every entry lowercase, ASCII, and space-separated — the query tests
+// assert that shape.
 
 // Query starters that pair naturally with a noun topic.
 export const SEARCH_LEAD_INS: string[] = [
     'best', 'cheapest', 'affordable', 'popular', 'top 10', 'where to buy',
     'reviews of', 'benefits of', 'what is', 'history of', 'ideas for',
     'how much is', 'best budget', 'guide to', 'facts about', 'types of',
+    'how to start', 'learning', 'beginner', 'cheap', 'local', 'top rated',
+    'comparing', 'best value', 'famous', 'modern', 'classic', 'must try',
+    'simple', 'everyday',
 ];
 
 // Everyday subjects people actually search for.
 export const SEARCH_TOPICS: string[] = [
     'coffee', 'espresso', 'pizza', 'sushi', 'tacos', 'ramen', 'breakfast',
     'smoothies', 'pasta', 'sourdough', 'chocolate', 'tea', 'restaurants',
-    'gardening', 'houseplants', 'succulents', 'hiking', 'camping', 'kayaking',
+    'bread', 'pancakes', 'curry', 'dumplings', 'barbecue', 'salads', 'soups',
+    'desserts', 'ice cream', 'coffee makers', 'air fryers', 'blenders',
+    'cookware', 'kitchen knives', 'baking', 'cocktails', 'wine', 'cheese',
+    'gardening', 'houseplants', 'succulents', 'herb gardens', 'composting',
+    'bonsai', 'orchids', 'gardens', 'interior design', 'recipes', 'meal prep',
+    'hiking', 'camping', 'kayaking', 'rock climbing', 'snorkeling',
+    'paddleboarding', 'trail running', 'backpacking', 'geocaching', 'archery',
     'running', 'cycling', 'swimming', 'yoga', 'pilates', 'meditation',
+    'marathons', 'tennis', 'basketball', 'soccer', 'skiing', 'surfing',
+    'bowling', 'badminton', 'table tennis', 'volleyball', 'golf', 'sailing',
+    'scuba diving', 'fishing', 'birdwatching',
     'photography', 'painting', 'pottery', 'woodworking', 'knitting', 'origami',
-    'guitar', 'piano', 'chess', 'board games', 'video games', 'puzzles',
+    'watercolour', 'calligraphy', 'sketching', 'sewing', 'quilting',
+    'jewellery making', 'candle making', 'model trains',
+    'guitar', 'piano', 'violin', 'drums', 'ukulele', 'singing', 'songwriting',
+    'music theory', 'chess', 'board games', 'video games', 'puzzles',
+    'crossword puzzles', 'sudoku', 'trivia', 'magic tricks',
     'movies', 'documentaries', 'podcasts', 'audiobooks', 'novels', 'comics',
     'astronomy', 'physics', 'biology', 'geography', 'history', 'languages',
     'budgeting', 'investing', 'productivity', 'nutrition', 'sleep', 'stretching',
-    'marathons', 'tennis', 'basketball', 'soccer', 'skiing', 'surfing',
-    'fishing', 'birdwatching', 'baking', 'cocktails', 'wine', 'cheese',
+    'public speaking', 'note taking', 'journaling', 'time management',
+    'habit tracking', 'resume writing', 'tidying',
     'dogs', 'cats', 'aquariums', 'road trips', 'national parks', 'beaches',
-    'mountains', 'waterfalls', 'museums', 'art galleries', 'concerts', 'festivals',
+    'mountains', 'waterfalls', 'museums', 'art galleries', 'concerts',
+    'festivals', 'budget travel', 'city breaks', 'train travel',
     'laptops', 'headphones', 'smartphones', 'cameras', 'keyboards', 'monitors',
     'standing desks', 'electric cars', 'solar panels', 'smart home', 'bicycles',
-    'interior design', 'gardens', 'recipes', 'meal prep', 'houseplants',
 ];
 
 // Suffixes that pair naturally with a noun topic.
 export const SEARCH_TAILS: string[] = [
     'near me', 'for beginners', 'reviews', 'ideas', 'tips', 'prices',
     'on a budget', 'explained', 'guide', 'deals', 'this weekend', 'at home',
-    'for kids', 'checklist', 'basics', 'trends',
+    'for kids', 'checklist', 'basics', 'trends', 'for two', 'in winter',
+    'in summer', 'step by step', 'comparison', 'alternatives', 'for families',
+    'for students', 'on sale', 'made easy', 'buying guide', 'recommendations',
+    'for small spaces', 'essentials',
 ];

--- a/wxt/entrypoints/utils/search.test.ts
+++ b/wxt/entrypoints/utils/search.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect } from 'vitest';
 import { toInt, buildSearchQuery, buildSearchUrl, nextDelayMinutes, shouldOpenMore } from './search';
 import { SEARCH_LEAD_INS, SEARCH_TOPICS, SEARCH_TAILS } from '../data/searchTerms';
 
+// Measures what the generator actually reaches, rather than trusting a formula
+// over the word lists that could drift from the shapes it really emits.
+function countDistinctQueries(samples: number): number {
+  const seen = new Set<string>();
+  for (let i = 0; i < samples; i++) seen.add(buildSearchQuery());
+  return seen.size;
+}
+
 const VOCAB = new Set(
   [...SEARCH_LEAD_INS, ...SEARCH_TOPICS, ...SEARCH_TAILS].flatMap((phrase) => phrase.split(' '))
 );
@@ -38,6 +46,21 @@ describe('buildSearchQuery', () => {
     for (let i = 0; i < 100; i++) seen.add(buildSearchQuery());
     expect(seen.size).toBeGreaterThan(20);
   });
+
+  // Microsoft does not credit a query it has already seen today, so the pool has
+  // to be large enough that a heavy day (90+ searches) rarely repeats itself.
+  it('can build at least 10k distinct queries', () => {
+    expect(countDistinctQueries(60_000)).toBeGreaterThanOrEqual(10_000);
+  });
+
+  it('rarely repeats a query across a heavy day of searches', () => {
+    const daysWithRepeat = Array.from({ length: 2000 }, () => {
+      const seen = new Set<string>();
+      for (let i = 0; i < 90; i++) seen.add(buildSearchQuery());
+      return seen.size < 90;
+    }).filter(Boolean).length;
+    expect(daysWithRepeat / 2000).toBeLessThan(0.1);
+  });
 });
 
 describe('buildSearchUrl', () => {
@@ -52,20 +75,33 @@ describe('nextDelayMinutes', () => {
   it('returns the base timeout in minutes when jitter is zero', () => {
     expect(nextDelayMinutes(60, 0)).toBeCloseTo(1, 5);
   });
-  it('floors at 0.1 for very small timeouts', () => {
-    expect(nextDelayMinutes(0, 0)).toBe(0.1);
-    expect(nextDelayMinutes(1, 0)).toBe(0.1);
+
+  // Regression: the spread used to reach down to 15s at the default 60s timeout.
+  // Chrome silently clamps any sub-30s alarm in a packed build, and searches
+  // arriving in that fast a burst risk not being credited at all.
+  it('never schedules an alarm below the 30s platform minimum', () => {
+    for (const timeout of [0, 1, 5, 20, 30, 60, 300]) {
+      for (let i = 0; i < 500; i++) {
+        expect(nextDelayMinutes(timeout)).toBeGreaterThanOrEqual(0.5 - 1e-9);
+      }
+    }
   });
-  it('spreads the delay ±75% around the base and varies between calls', () => {
+
+  it('spreads the delay ±50% around the base and varies between calls', () => {
     const values = new Set<number>();
-    for (let i = 0; i < 300; i++) {
+    for (let i = 0; i < 500; i++) {
       const v = nextDelayMinutes(60);
       values.add(v);
-      // base 60s → [15s, 105s] → [0.25, 1.75] minutes
-      expect(v).toBeGreaterThanOrEqual(0.25 - 1e-9);
-      expect(v).toBeLessThanOrEqual(1.75 + 1e-9);
+      // base 60s → [30s, 90s] → [0.5, 1.5] minutes
+      expect(v).toBeGreaterThanOrEqual(0.5 - 1e-9);
+      expect(v).toBeLessThanOrEqual(1.5 + 1e-9);
     }
     expect(values.size).toBeGreaterThan(50);
+  });
+
+  it('keeps the configured timeout as the average', () => {
+    const mean = Array.from({ length: 20000 }, () => nextDelayMinutes(120)).reduce((a, b) => a + b, 0) / 20000;
+    expect(mean).toBeCloseTo(2, 1);
   });
 });
 

--- a/wxt/entrypoints/utils/search.ts
+++ b/wxt/entrypoints/utils/search.ts
@@ -15,32 +15,48 @@ function pick<T>(arr: T[]): T {
     return arr[getRndInteger(0, arr.length - 1)];
 }
 
-// Build a natural-looking search query from real words — "<lead-in> <topic>" or
-// "<topic> <tail>" — so it reads like a normal search (e.g. "best headphones",
-// "gardening for beginners") with no random-character prefix or gibberish.
+// Build a natural-looking search query from real words — "<lead-in> <topic>",
+// "<topic> <tail>", or "<lead-in> <topic> <tail>" — so it reads like a normal
+// search ("best headphones", "gardening for beginners", "cheap laptops on sale")
+// with no random-character prefix or gibberish.
+//
+// The three-part shape is favoured 6:1:1 because it is where nearly all of the
+// pool lives (lead-ins x topics x tails), and a repeated query earns no points:
+// weighting it this way puts the effective pool in the tens of thousands instead
+// of the ~4.5k either two-part shape can reach on its own.
 export function buildSearchQuery(): string {
     const topic = pick(SEARCH_TOPICS);
-    return getRndInteger(0, 1) === 0
-        ? `${pick(SEARCH_LEAD_INS)} ${topic}`
-        : `${topic} ${pick(SEARCH_TAILS)}`;
+    switch (getRndInteger(0, 7)) {
+        case 0:
+            return `${pick(SEARCH_LEAD_INS)} ${topic}`;
+        case 1:
+            return `${topic} ${pick(SEARCH_TAILS)}`;
+        default:
+            return `${pick(SEARCH_LEAD_INS)} ${topic} ${pick(SEARCH_TAILS)}`;
+    }
 }
 
 export function buildSearchUrl(query: string): string {
     return `${BING_SEARCH_URL}${encodeURIComponent(query)}${BING_SEARCH_PARAMS}`;
 }
 
-// Fraction of the configured gap used as a symmetric random spread, so the
-// time between searches varies widely (base ±75%) instead of being near-fixed —
-// looks less robotic. Averages the user's configured timeout. Chrome/Firefox
-// alarms take minutes; floor at 0.1 so the value is never 0 (Chrome still
-// clamps sub-minute alarms in packed builds regardless).
-const DELAY_JITTER_FRACTION = 0.75;
+// Fraction of the configured gap used as a symmetric random spread, so the time
+// between searches varies (base ±50%) instead of being near-fixed — looks less
+// robotic while still averaging the user's configured timeout. At the default
+// 60s timeout this keeps every gap at or above MIN_DELAY_SECONDS without the
+// clamp below having to bite.
+const DELAY_JITTER_FRACTION = 0.5;
+
+// Hard floor on the gap between searches. Chrome silently clamps any alarm under
+// 30s in a packed build, so anything shorter is fiction there — and searches that
+// do arrive in that fast a burst risk not being credited at all.
+const MIN_DELAY_SECONDS = 30;
 
 export function nextDelayMinutes(timeoutSeconds: number, jitterMs?: number): number {
     const baseMs = Math.max(timeoutSeconds, 1) * 1000;
     const spread = Math.round(baseMs * DELAY_JITTER_FRACTION);
     const jitter = jitterMs ?? getRndInteger(-spread, spread);
-    return Math.max((baseMs + jitter) / 60000, 0.1);
+    return Math.max(baseMs + jitter, MIN_DELAY_SECONDS * 1000) / 60000;
 }
 
 // True while another search tab should open. Opening exactly `searches` tabs

--- a/wxt/entrypoints/utils/settings.ts
+++ b/wxt/entrypoints/utils/settings.ts
@@ -9,7 +9,9 @@ export const DEFAULTS = {
     closeTime: 5,
     // When on, each search tab opens its first organic result after a short
     // random delay (without stealing focus); otherwise the tab just loads the SERP.
-    openFirstResult: true,
+    // Off by default: navigating off the results page risks the search not being
+    // credited, so this stays opt-in.
+    openFirstResult: false,
 } as const;
 
 // Selecting an account level sets a sensible default number of daily searches

--- a/wxt/package-lock.json
+++ b/wxt/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "microsoft-automatic-rewards",
-  "version": "2.2.9",
+  "name": "search-automatic-rewards",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "microsoft-automatic-rewards",
-      "version": "2.2.9",
+      "name": "search-automatic-rewards",
+      "version": "3.0.4",
       "hasInstallScript": true,
       "dependencies": {
         "react": "^19.1.0",

--- a/wxt/package.json
+++ b/wxt/package.json
@@ -2,7 +2,7 @@
   "name": "search-automatic-rewards",
   "description": "Script that gives you maximum amount of microsoft rewards points every day automatically or by a click of a button.",
   "private": true,
-  "version": "3.0.3",
+  "version": "3.0.4",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
## Why

A lot of users reported that daily searches stopped working after the WXT migration and 3.0.2. Root cause, confirmed by running the real code:

`runRewards()` awaited `openDailyRewards()` before starting the searches, and that call ends on a promise that only resolves when the dashboard tab reports `status: 'complete'`. There was no timeout. A dashboard closed by the user, removed by the flow's own 90s safety timer, or lost to a torn-down MV3 service worker left that promise pending **forever**, so `startSearches` was never reached — no search tabs, and `isSearching` never flipped, so the popup showed no run at all.

Instrumenting the shipped path made it unambiguous:

```
[PROBE] runRewards -> HUNG
[PROBE] tabs opened: [ 'https://rewards.bing.com/dashboard' ]
```

The legacy background deliberately fired the two flows independently (`chrome/src/background.ts:154-155` called `openDailyRewards()` *without* awaiting it). The WXT port turned that into a blocking await, introduced in `ac34525` ("3.0.2 version", which despite the message rewrote the background scheduling).

## What changed

**1. Searches run independently of the daily set** (`390b2e5`)
- The daily set is fire-and-forget again; the searches can no longer be blocked by it.
- Its dashboard load wait is bounded (30s) so it cannot leak a pending promise either.
- Restores the `active` / `autoDaily` gates that `ac34525` dropped from `runRewards`, so "Daily set" off no longer opens the dashboard and "Daily searches" off no longer opens one search tab before the next alarm step stops the run.
- `openFirstResult` now defaults to **off** for new installs: navigating the search tab off the Bing results page risks the search not being credited, so it stays opt-in.

**2. Query pool and search cadence** (`ad51449`)
- The pool was ~3k combinations and Microsoft credits a query only once, so heavy days repeated themselves constantly. Adds a `<lead-in> <topic> <tail>` shape (weighted 6:1:1, since that is where nearly all the pool lives) and grows the lists to 30/154/30. The generator now reaches ~120k distinct queries.

  | Searches/day | Days with a repeat (before → after) |
  |---|---|
  | 20 | 6.3% → **0.2%** |
  | 30 | 14.1% → **0.5%** |
  | 90 | 73.8% → **4.0%** |

- The ±75% spread put 16.7% of gaps under 30s at the default 60s timeout (as low as 15s). Chrome silently clamps sub-30s alarms in a packed build anyway, and searches arriving that fast risk not being credited. Narrowed to ±50% with a hard 30s floor: timeout=60s now yields **30–90s gaps averaging exactly 60s, nothing under 30s** at any configured timeout.

**3. Tabs now actually close** (`8622824`)
- Every close depended on a `setTimeout` plus a `tabs.onUpdated` listener registered at runtime. Chrome tears an MV3 worker down after ~30s idle and neither survives that, so tabs were left open — the dashboard's 90s lifetime and the 20s daily-link cap were past the idle window *by design*.
- Adds a registry of opened tab ids with absolute deadlines, swept by a repeating alarm. Alarms do wake a dead worker, and the dispatch is registered at the worker's top level. The precise timer still closes on time while the worker is alive; the sweep is the backstop. The alarm is armed only while tabs are tracked, so it does not wake the worker for the rest of the session.
- Search-tab deadlines allow a further 60s for page load on top of the configured close time, so a slow page is never swept away before its search registers.
- `stopSearches` / `handleStartup` no longer call `alarms.clearAll()`, which would have wiped the sweep along with the run's own alarm.

**4. Content-script cleanup** (`bb644e2`)
- Removes the two `console` statements and the header claiming the script was local-analysis only and not for shipping.

**5. Version → 3.0.4** (`95dd1f8`), plus aligning the lockfile name left stale by the 3.0.1 rename.

## Test plan

- [x] `npm run test` — 58 passing (was 37; +21)
  - New `dailySchedule.test.ts`: the regression itself — **"starts the searches even when the dashboard never reports complete"** (timed out at 5s before the fix), plus both toggles on the popup path *and* the browser-startup path.
  - New `tabCleanup.test.ts` (8): closes past deadline, leaves future deadlines alone, disarms when empty, untracked tabs, already-gone tabs, registry reset.
  - `searchRunner.test.ts`: `stopSearches` leaves the cleanup alarm running; each search tab is registered for the sweep.
  - `search.test.ts`: no alarm below the 30s floor at any timeout, mean equals the configured timeout, ≥10k distinct queries measured **from the generator** (not a formula over the word lists), repeat rate under a heavy day.
- [x] `npm run compile` — clean
- [x] `npm run build` + `npm run build:firefox` — both green
- [x] Verified in the shipped bundle: `i&&V().catch(()=>{}),a&&n>0&&await G(t,n,r)` (daily set no longer awaited, both gates present); `openFirstResult:!1`; `clearAll` gone; zero `console.` in either `bingResult.js`
- [x] Prod zips built and inspected: 3.0.4, MV3 + MV2 manifests correct, 21 files, no source or test artifacts
- [ ] Manual smoke test in Chrome and Firefox: browser restart triggers a run, searches complete with "Daily set" unchecked, all tabs close

## Notes for the reviewer

- **This PR also carries `aa8a90e`** ("remove legacy chrome/firefox trees"), which was left unmerged on `refactor/wxt-migration` after PR #24. It needs to land anyway, but flagging it so the diff size isn't a surprise.
- **Behaviour change:** with "Daily searches" unchecked, "Get rewards" now runs *no* searches (3.0.2 opened one, then the next alarm step stopped the run). This matches the tooltip and the existing check in `handleAlarmStep`, so the flow is finally self-consistent.
- **Existing 3.0.x users keep `openFirstResult: true`** if it is already stored — only new installs and 2.x upgraders get it off. Flipping existing users would need a migration; say the word.
- **Not addressed here:** the dashboard still opens `active: true` and force-refocuses itself (`dailyRewards.ts:29,36`). The sweep now guarantees it gets closed, but that focus-stealing is what drove users to close the tab and trigger the hang in the first place — worth a follow-up.
